### PR TITLE
Update methods from latest changes in stark-curve

### DIFF
--- a/math/src/curve/mod.rs
+++ b/math/src/curve/mod.rs
@@ -341,7 +341,12 @@ impl AffinePoint {
 
     /// Attempts to deserialize a compressed element.
     pub fn from_compressed(bytes: &[u8; 32]) -> Option<Self> {
-        AffinePointInner::from_compressed(bytes).map(AffinePoint)
+        let tmp = AffinePointInner::from_compressed(bytes);
+        if tmp.is_some().into() {
+            Some(AffinePoint(tmp.unwrap()))
+        } else {
+            None
+        }
     }
 
     /// Constructs an `AffinePoint` element without checking that it is a valid point.

--- a/math/src/curve/scalar.rs
+++ b/math/src/curve/scalar.rs
@@ -117,7 +117,7 @@ impl Scalar {
 
     /// Convert a little-endian bit sequence into a Scalar element
     pub fn from_bits(bit_slice: &BitSlice<Lsb0, u8>) -> Scalar {
-        Scalar(ScalarInner::from_bits_vartime(bit_slice))
+        Scalar(ScalarInner::from_bits(bit_slice))
     }
 
     pub fn to_bytes(&self) -> [u8; 32] {
@@ -418,9 +418,15 @@ mod tests {
     }
 
     #[test]
-    fn test_to_repr() {
-        assert_eq!(format!("{:?}", Scalar::zero().to_repr()), "[0, 0, 0, 0]");
-        assert_eq!(format!("{:?}", Scalar::one().to_repr()), "[1, 0, 0, 0]");
+    fn test_output_reduced_limbs() {
+        assert_eq!(
+            format!("{:?}", Scalar::zero().output_reduced_limbs()),
+            "[0, 0, 0, 0]"
+        );
+        assert_eq!(
+            format!("{:?}", Scalar::one().output_reduced_limbs()),
+            "[1, 0, 0, 0]"
+        );
     }
 
     // BASIC ALGEBRA

--- a/math/src/field/f252/mod.rs
+++ b/math/src/field/f252/mod.rs
@@ -180,7 +180,12 @@ impl BaseElement {
 
     /// Computes the square root of this element, if it exists.
     pub fn sqrt(&self) -> Option<Self> {
-        self.0.sqrt_vartime().map(BaseElement)
+        let tmp = self.0.sqrt();
+        if bool::from(tmp.is_none()) {
+            None
+        } else {
+            Some(BaseElement(tmp.unwrap()))
+        }
     }
 }
 
@@ -302,7 +307,7 @@ impl StarkField for BaseElement {
     }
 
     fn to_repr(&self) -> Self::Representation {
-        Repr(self.0.to_repr())
+        Repr(self.0.output_reduced_limbs())
     }
 }
 


### PR DESCRIPTION
Required modifications with breaking change of the stark-curve repo.
A bit cumbersome as we are going to drop the need for the wrapper structs here but necessary in the meantime for the CI to go green on the other repos.