### PR TITLE
Empty Merkle tree construction

### DIFF
--- a/crypto/benches/merkle.rs
+++ b/crypto/benches/merkle.rs
@@ -8,7 +8,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use math::fields::f128::BaseElement;
 use rand_utils::rand_value;
 use utils::uninit_vector;
-use winter_crypto::{build_merkle_nodes, concurrent, hashers::Blake3_256, Hasher};
+use winter_crypto::{build_merkle_nodes, concurrent, hashers::Blake3_256, Hasher, MerkleTree};
 
 type Blake3 = Blake3_256<BaseElement>;
 type Blake3Digest = <Blake3 as Hasher>::Digest;
@@ -35,5 +35,23 @@ pub fn merkle_tree_construction(c: &mut Criterion) {
     }
 }
 
-criterion_group!(merkle_group, merkle_tree_construction,);
+pub fn empty_merkle_tree_construction(c: &mut Criterion) {
+    let mut merkle_group = c.benchmark_group("empty merkle tree");
+
+    static DEPTHS: [usize; 3] = [3, 7, 15];
+
+    let empty_leaf =  Blake3::hash(&rand_value::<u128>().to_le_bytes());
+
+    for depth in DEPTHS {
+        merkle_group.bench_function(BenchmarkId::new("construction", depth), |bench| {
+            bench.iter(|| MerkleTree::<Blake3>::build_empty(depth, empty_leaf))
+        });
+    }
+}
+
+criterion_group!(
+    merkle_group,
+    merkle_tree_construction,
+    empty_merkle_tree_construction
+);
 criterion_main!(merkle_group);

--- a/crypto/benches/merkle.rs
+++ b/crypto/benches/merkle.rs
@@ -40,11 +40,9 @@ pub fn empty_merkle_tree_construction(c: &mut Criterion) {
 
     static DEPTHS: [usize; 3] = [3, 7, 15];
 
-    let empty_leaf =  Blake3::hash(&rand_value::<u128>().to_le_bytes());
-
     for depth in DEPTHS {
         merkle_group.bench_function(BenchmarkId::new("construction", depth), |bench| {
-            bench.iter(|| MerkleTree::<Blake3>::build_empty(depth, empty_leaf))
+            bench.iter(|| MerkleTree::<Blake3>::build_empty(depth))
         });
     }
 }

--- a/crypto/src/merkle/mod.rs
+++ b/crypto/src/merkle/mod.rs
@@ -127,6 +127,32 @@ impl<H: Hasher> MerkleTree<H> {
         Ok(MerkleTree { nodes, leaves })
     }
 
+    /// Returns new Merkle tree built from default, empty leaves using hash function
+    /// specified by the `H` generic parameter.
+    pub fn build_empty(depth: usize, empty_leaf: H::Digest) -> Result<Self, MerkleTreeError> {
+        // Calculate number of leaves
+        let n = 2usize.pow(depth as u32);
+        // Build the leaves
+        let leaves = vec![empty_leaf; n];
+        // Determing hash values for nodes depending upon level
+        let mut cur_empty = empty_leaf;
+        let mut empty_nodes = Vec::new();
+        for _ in 0..depth {
+            cur_empty = H::merge(&[cur_empty, cur_empty]);
+            empty_nodes.push(cur_empty);
+        }
+        // Begin with an empty internal node set
+        let mut nodes = vec![cur_empty];
+        let mut num_nodes = 1;
+        // Fill the nodes for each level
+        for empty_node in empty_nodes.iter().rev() {
+            nodes.append(&mut vec![*empty_node; num_nodes]);
+            num_nodes *= 2;
+        }
+
+        Ok(MerkleTree { nodes, leaves })
+    }
+
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This adds a method to construct a Merkle tree based on leaf hashes of all zeroes. In cases of high-depth Merkle trees, the use of pre-computed internal hashes speeds up construction considerably.