### PR TITLE
`ProofOptions` Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,10 +281,10 @@ Now, we are finally ready to generate a STARK proof. The function below, will ex
 ```Rust
 use winterfell::{
     math::{fields::f128::BaseElement, FieldElement},
-    FieldExtension, HashFunction, ProofOptions, StarkProof,
+    BlowupFactor, FieldExtension, FriFoldingFactor, FriMaximumRemainderSize, HashFunction, ProofOptions, ProofOptionError, StarkProof,
 };
 
-pub fn prove_work() -> (BaseElement, StarkProof) {
+pub fn prove_work() -> Result<(BaseElement, StarkProof), ProofOptionError> {
     // We'll just hard-code the parameters here for this example.
     let start = BaseElement::new(3);
     let n = 1_048_576;
@@ -296,18 +296,18 @@ pub fn prove_work() -> (BaseElement, StarkProof) {
     // Define proof options; these will be enough for ~96-bit security level.
     let options = ProofOptions::new(
         32, // number of queries
-        8,  // blowup factor
+        BlowupFactor::Third,  // blowup factor
         0,  // grinding factor
         FieldExtension::None,
-        8,   // FRI folding factor
-        128, // FRI max remainder length
-    );
+        FriFoldingFactor::Third,   // FRI folding factor
+        FriMaximumRemainderSize::Fourth, // FRI max remainder length
+    )?;
 
     // Instantiate the prover and generate the proof.
     let prover = WorkProver::new(options);
     let proof = prover.prove(trace).unwrap();
 
-    (result, proof)
+    Ok((result, proof))
 }
 ```
 

--- a/air/src/air/tests.rs
+++ b/air/src/air/tests.rs
@@ -8,7 +8,9 @@ use super::{
     Air, AirContext, Assertion, EvaluationFrame, ProofOptions, TraceInfo,
     TransitionConstraintDegree,
 };
-use crate::{AuxTraceRandElements, FieldExtension};
+use crate::{
+    AuxTraceRandElements, BlowupFactor, FieldExtension, FriFoldingFactor, FriMaximumRemainderSize,
+};
 use crypto::{hashers::Blake3_256, RandomCoin};
 use math::{fields::f128::BaseElement, get_power_series, log2, polynom, FieldElement, StarkField};
 use utils::collections::{BTreeMap, Vec};
@@ -235,7 +237,15 @@ impl MockAir {
         let mut result = Self::new(
             TraceInfo::with_meta(4, trace_length, vec![1]),
             (),
-            ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 256),
+            ProofOptions::new(
+                32,
+                BlowupFactor::Third,
+                0,
+                FieldExtension::None,
+                FriFoldingFactor::First,
+                FriMaximumRemainderSize::Fourth,
+            )
+            .expect("Proof options should be valid"),
         );
         result.periodic_columns = column_values;
         result
@@ -245,7 +255,15 @@ impl MockAir {
         let mut result = Self::new(
             TraceInfo::with_meta(4, trace_length, vec![assertions.len() as u8]),
             (),
-            ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 256),
+            ProofOptions::new(
+                32,
+                BlowupFactor::Third,
+                0,
+                FieldExtension::None,
+                FriFoldingFactor::First,
+                FriMaximumRemainderSize::Fourth,
+            )
+            .expect("Proof options should be valid"),
         );
         result.assertions = assertions;
         result
@@ -295,7 +313,15 @@ pub fn build_context<B: StarkField>(
     trace_width: usize,
     num_assertions: usize,
 ) -> AirContext<B> {
-    let options = ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 256);
+    let options = ProofOptions::new(
+        32,
+        BlowupFactor::Third,
+        0,
+        FieldExtension::None,
+        FriFoldingFactor::First,
+        FriMaximumRemainderSize::Fourth,
+    )
+    .expect("Proof options should be valid");
     let t_degrees = vec![TransitionConstraintDegree::new(2)];
     let trace_info = TraceInfo::new(trace_width, trace_length);
     AirContext::new(trace_info, t_degrees, num_assertions, options)

--- a/air/src/air/transition/degree.rs
+++ b/air/src/air/transition/degree.rs
@@ -121,7 +121,7 @@ impl TransitionConstraintDegree {
         let degree_bound = self.base + self.cycles.len() - 1;
         cmp::max(
             degree_bound.next_power_of_two(),
-            ProofOptions::MIN_BLOWUP_FACTOR,
+            ProofOptions::MIN_BLOWUP_FACTOR.into(),
         )
     }
 }

--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -40,7 +40,9 @@ mod errors;
 pub use errors::AssertionError;
 
 mod options;
-pub use options::{FieldExtension, ProofOptions};
+pub use options::{
+    BlowupFactor, FieldExtension, FriFoldingFactor, FriMaximumRemainderSize, ProofOptions,
+};
 
 mod air;
 pub use air::{

--- a/air/src/options.rs
+++ b/air/src/options.rs
@@ -6,7 +6,9 @@
 
 use fri::FriOptions;
 use math::StarkField;
-use utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
+use utils::{
+    ByteReader, ByteWriter, Deserializable, DeserializationError, ProofOptionError, Serializable,
+};
 
 // TYPES AND INTERFACES
 // ================================================================================================
@@ -33,6 +35,157 @@ pub enum FieldExtension {
     Quadratic = 2,
     /// Composition polynomial is constructed in the cubic extension of the base field.
     Cubic = 3,
+}
+
+/// Represents the FRI folding factor option, a power of two
+#[repr(u8)]
+pub enum FriFoldingFactor {
+    First = 4,
+    Second = 8,
+    Third = 16,
+}
+
+impl From<FriFoldingFactor> for u8 {
+    fn from(factor: FriFoldingFactor) -> Self {
+        match factor {
+            FriFoldingFactor::First => 4,
+            FriFoldingFactor::Second => 8,
+            FriFoldingFactor::Third => 16,
+        }
+    }
+}
+
+impl TryFrom<u8> for FriFoldingFactor {
+    type Error = DeserializationError;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            4 => Ok(FriFoldingFactor::First),
+            8 => Ok(FriFoldingFactor::Second),
+            16 => Ok(FriFoldingFactor::Third),
+            x => Err(DeserializationError::UnknownError(format!(
+                "Unexpected folding factor of {x}"
+            ))),
+        }
+    }
+}
+
+/// Represents the blowup factor option, a power of two
+#[repr(u8)]
+pub enum BlowupFactor {
+    First = 2,
+    Second = 4,
+    Third = 8,
+    Fourth = 16,
+    Fifth = 32,
+    Sixth = 64,
+    Seventh = 128,
+}
+
+impl From<BlowupFactor> for u8 {
+    fn from(factor: BlowupFactor) -> Self {
+        use BlowupFactor::{Fifth, First, Fourth, Second, Seventh, Sixth, Third};
+        match factor {
+            First => 2,
+            Second => 4,
+            Third => 8,
+            Fourth => 16,
+            Fifth => 32,
+            Sixth => 64,
+            Seventh => 128,
+        }
+    }
+}
+
+impl From<BlowupFactor> for usize {
+    fn from(factor: BlowupFactor) -> Self {
+        u8::from(factor).into()
+    }
+}
+
+impl TryFrom<u8> for BlowupFactor {
+    type Error = DeserializationError;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        use BlowupFactor::{Fifth, First, Fourth, Second, Seventh, Sixth, Third};
+        match value {
+            2 => Ok(First),
+            4 => Ok(Second),
+            8 => Ok(Third),
+            16 => Ok(Fourth),
+            32 => Ok(Fifth),
+            64 => Ok(Sixth),
+            128 => Ok(Seventh),
+            x => Err(DeserializationError::UnknownError(format!(
+                "Unexpected blowup factor of {x}"
+            ))),
+        }
+    }
+}
+
+impl TryFrom<usize> for BlowupFactor {
+    type Error = DeserializationError;
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        u8::try_from(value)
+            .map_err(|_| {
+                DeserializationError::UnknownError(format!("Unexpected blowup factor of {value}"))
+            })
+            .and_then(TryInto::try_into)
+    }
+}
+
+/// Represents the max remainder size proof option, as a power of 2
+#[repr(u16)]
+pub enum FriMaximumRemainderSize {
+    First = 32,
+    Second = 64,
+    Third = 128,
+    Fourth = 256,
+    Fifth = 512,
+    Sixth = 1024,
+}
+
+impl From<FriMaximumRemainderSize> for u16 {
+    fn from(size: FriMaximumRemainderSize) -> Self {
+        use FriMaximumRemainderSize::{Fifth, First, Fourth, Second, Sixth, Third};
+        match size {
+            First => 32,
+            Second => 64,
+            Third => 128,
+            Fourth => 256,
+            Fifth => 512,
+            Sixth => 1024,
+        }
+    }
+}
+
+impl TryFrom<u16> for FriMaximumRemainderSize {
+    type Error = DeserializationError;
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        use FriMaximumRemainderSize::{Fifth, First, Fourth, Second, Sixth, Third};
+        match value {
+            32 => Ok(First),
+            64 => Ok(Second),
+            128 => Ok(Third),
+            256 => Ok(Fourth),
+            512 => Ok(Fifth),
+            1024 => Ok(Sixth),
+            x => Err(DeserializationError::UnknownError(format!(
+                "Unexpected FRI maximum remainder size of {x}"
+            ))),
+        }
+    }
+}
+
+impl TryFrom<usize> for FriMaximumRemainderSize {
+    type Error = DeserializationError;
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        u16::try_from(value)
+            .map_err(|_| {
+                DeserializationError::UnknownError(format!(
+                    "Unexpected FRI maximum remainder size of {value}"
+                ))
+            })
+            .and_then(TryInto::try_into)
+    }
 }
 
 /// STARK protocol parameters.
@@ -64,7 +217,7 @@ pub struct ProofOptions {
     grinding_factor: u8,
     field_extension: FieldExtension,
     fri_folding_factor: u8,
-    fri_max_remainder_size: u8, // stored as power of 2
+    fri_max_remainder_size: u32,
 }
 
 // PROOF OPTIONS IMPLEMENTATION
@@ -78,54 +231,36 @@ impl ProofOptions {
     /// The smallest allowed blowup factor for a given computation is derived from degrees of
     /// constraints defined for that computation and may be greater than 2. But no computation may
     /// have a blowup factor smaller than 2.
-    pub const MIN_BLOWUP_FACTOR: usize = 2;
+    pub const MIN_BLOWUP_FACTOR: BlowupFactor = BlowupFactor::First;
 
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
     /// Returns a new instance of [ProofOptions] struct constructed from the specified parameters.
     ///
-    /// # Panics
-    /// Panics if:
+    /// # Errors
+    /// Errors if:
     /// * `num_queries` is zero or greater than 128.
-    /// * `blowup_factor` is smaller than 4, greater than 256, or is not a power of two.
     /// * `grinding_factor` is greater than 32.
-    /// * `fri_folding_factor` is not 4, 8, or 16.
-    /// * `fri_max_remainder_size` is smaller than 32, greater than 1024, or is not a power of two.
     #[rustfmt::skip]
     pub fn new(
-        num_queries: usize,
-        blowup_factor: usize,
-        grinding_factor: u32,
+        num_queries: u8,
+        blowup_factor: BlowupFactor,
+        grinding_factor: u8,
         field_extension: FieldExtension,
-        fri_folding_factor: usize,
-        fri_max_remainder_size: usize,
-    ) -> ProofOptions {
-        // TODO: return errors instead of panicking
-        assert!(num_queries > 0, "number of queries must be greater than 0");
-        assert!(num_queries <= 128, "number of queries cannot be greater than 128");
-
-        assert!(blowup_factor.is_power_of_two(), "blowup factor must be a power of 2");
-        assert!(blowup_factor >= Self::MIN_BLOWUP_FACTOR,
-            "blowup factor cannot be smaller than {}", Self::MIN_BLOWUP_FACTOR);
-        assert!(blowup_factor <= 128, "blowup factor cannot be greater than 128");
-
-        assert!(grinding_factor <= 32, "grinding factor cannot be greater than 32");
-
-        assert!(fri_folding_factor.is_power_of_two(), "FRI folding factor must be a power of 2");
-        assert!(fri_folding_factor >= 4, "FRI folding factor cannot be smaller than 4");
-        assert!(fri_folding_factor <= 16, "FRI folding factor cannot be greater than 16");
-
-        assert!(fri_max_remainder_size.is_power_of_two(), "FRI max remainder size must be a power of 2");
-        assert!(fri_max_remainder_size >= 32, "FRI max remainder size cannot be smaller than 32");
-        assert!(fri_max_remainder_size <= 1024, "FRI max remainder size cannot be greater than 1024");
-
-        ProofOptions {
-            num_queries: num_queries as u8,
-            blowup_factor: blowup_factor as u8,
-            grinding_factor: grinding_factor as u8,
-            field_extension,
-            fri_folding_factor: fri_folding_factor as u8,
-            fri_max_remainder_size: fri_max_remainder_size.trailing_zeros() as u8,
+        fri_folding_factor: FriFoldingFactor,
+        fri_max_remainder_size: FriMaximumRemainderSize,
+    ) -> Result<ProofOptions, ProofOptionError> {
+        match (num_queries, grinding_factor) {
+            (queries, _) if queries > 128 => Err(ProofOptionError::NumberOfQueries),
+            (_, factor) if factor > 32 => Err(ProofOptionError::GrindingFactor),
+            (_, _) => Ok(ProofOptions {
+                num_queries,
+                blowup_factor: blowup_factor.into(),
+                grinding_factor,
+                field_extension,
+                fri_folding_factor: fri_folding_factor.into(),
+                fri_max_remainder_size: u16::from(fri_max_remainder_size).trailing_zeros(),
+            })
         }
     }
 
@@ -181,8 +316,8 @@ impl ProofOptions {
 
     /// Returns options for FRI protocol instantiated with parameters from this proof options.
     pub fn to_fri_options(&self) -> FriOptions {
-        let folding_factor = self.fri_folding_factor as usize;
-        let max_remainder_size = 2usize.pow(self.fri_max_remainder_size as u32);
+        let folding_factor = usize::from(self.fri_folding_factor);
+        let max_remainder_size = 2usize.pow(self.fri_max_remainder_size);
         FriOptions::new(self.blowup_factor(), folding_factor, max_remainder_size)
     }
 }
@@ -195,7 +330,7 @@ impl Serializable for ProofOptions {
         target.write_u8(self.grinding_factor);
         target.write(self.field_extension);
         target.write_u8(self.fri_folding_factor);
-        target.write_u8(self.fri_max_remainder_size);
+        target.write_u32(self.fri_max_remainder_size);
     }
 }
 
@@ -205,14 +340,15 @@ impl Deserializable for ProofOptions {
     /// # Errors
     /// Returns an error of a valid proof options could not be read from the specified `source`.
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        Ok(ProofOptions::new(
-            source.read_u8()? as usize,
-            source.read_u8()? as usize,
-            source.read_u8()? as u32,
+        ProofOptions::new(
+            source.read_u8()?,
+            source.read_u8()?.try_into()?,
+            source.read_u8()?,
             FieldExtension::read_from(source)?,
-            source.read_u8()? as usize,
-            2usize.pow(source.read_u8()? as u32),
-        ))
+            source.read_u8()?.try_into()?,
+            2usize.pow(source.read_u16()?.into()).try_into()?,
+        )
+        .map_err(Into::into)
     }
 }
 

--- a/examples/benches/fibonacci.rs
+++ b/examples/benches/fibonacci.rs
@@ -8,7 +8,8 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use examples::{fibonacci, Example};
 use std::time::Duration;
 use winterfell::{
-    crypto::hashers::Blake3_256, math::fields::f128::BaseElement, FieldExtension, ProofOptions,
+    crypto::hashers::Blake3_256, math::fields::f128::BaseElement, BlowupFactor, FieldExtension,
+    FriFoldingFactor, FriMaximumRemainderSize, ProofOptions,
 };
 
 const SIZES: [usize; 3] = [16_384, 65_536, 262_144];
@@ -18,7 +19,15 @@ fn fibonacci(c: &mut Criterion) {
     group.sample_size(10);
     group.measurement_time(Duration::from_secs(20));
 
-    let options = ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 256);
+    let options = ProofOptions::new(
+        32,
+        BlowupFactor::Third,
+        0,
+        FieldExtension::None,
+        FriFoldingFactor::First,
+        FriMaximumRemainderSize::Fourth,
+    )
+    .expect("Proof options should be valid");
 
     for &size in SIZES.iter() {
         let fib =

--- a/examples/benches/rescue.rs
+++ b/examples/benches/rescue.rs
@@ -9,7 +9,8 @@ use examples::{rescue, Example};
 
 use std::time::Duration;
 use winterfell::{
-    crypto::hashers::Blake3_256, math::fields::f128::BaseElement, FieldExtension, ProofOptions,
+    crypto::hashers::Blake3_256, math::fields::f128::BaseElement, BlowupFactor, FieldExtension,
+    FriFoldingFactor, FriMaximumRemainderSize, ProofOptions,
 };
 
 const SIZES: [usize; 2] = [256, 512];
@@ -19,7 +20,15 @@ fn rescue(c: &mut Criterion) {
     group.sample_size(10);
     group.measurement_time(Duration::from_secs(25));
 
-    let options = ProofOptions::new(32, 32, 0, FieldExtension::None, 4, 256);
+    let options = ProofOptions::new(
+        32,
+        BlowupFactor::Fifth,
+        0,
+        FieldExtension::None,
+        FriFoldingFactor::First,
+        FriMaximumRemainderSize::Fourth,
+    )
+    .expect("Proof options should be valid");
 
     for &size in SIZES.iter() {
         let resc = rescue::rescue_128::RescueExample::<Blake3_256<BaseElement>>::new(

--- a/examples/src/fibonacci/utils.rs
+++ b/examples/src/fibonacci/utils.rs
@@ -32,12 +32,22 @@ pub fn compute_mulfib_term(n: usize) -> BaseElement {
 
 #[cfg(test)]
 pub fn build_proof_options(use_extension_field: bool) -> winterfell::ProofOptions {
-    use winterfell::{FieldExtension, ProofOptions};
+    use winterfell::{
+        BlowupFactor, FieldExtension, FriFoldingFactor, FriMaximumRemainderSize, ProofOptions,
+    };
 
     let extension = if use_extension_field {
         FieldExtension::Quadratic
     } else {
         FieldExtension::None
     };
-    ProofOptions::new(28, 8, 0, extension, 4, 256)
+    ProofOptions::new(
+        28,
+        BlowupFactor::Third,
+        0,
+        extension,
+        FriFoldingFactor::First,
+        FriMaximumRemainderSize::Fourth,
+    )
+    .expect("Proof options should be valid")
 }

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -6,8 +6,8 @@
 
 use structopt::StructOpt;
 use winterfell::{
-    crypto::hashers::Rp64_256, math::fields::f128::BaseElement, FieldExtension, ProofOptions,
-    StarkProof, VerifierError,
+    crypto::hashers::Rp64_256, math::fields::f128::BaseElement, BlowupFactor, FieldExtension,
+    FriFoldingFactor, FriMaximumRemainderSize, ProofOptions, StarkProof, VerifierError,
 };
 
 pub mod fibonacci;
@@ -52,7 +52,7 @@ pub struct ExampleOptions {
 
     /// Number of queries to include in a proof
     #[structopt(short = "q", long = "queries")]
-    num_queries: Option<usize>,
+    num_queries: Option<u8>,
 
     /// Blowup factor for low degree extension
     #[structopt(short = "b", long = "blowup")]
@@ -60,7 +60,7 @@ pub struct ExampleOptions {
 
     /// Grinding factor for query seed
     #[structopt(short = "g", long = "grinding", default_value = "16")]
-    grinding_factor: u32,
+    grinding_factor: u8,
 
     /// Field extension degree for composition polynomial
     #[structopt(short = "e", long = "field_extension", default_value = "1")]
@@ -72,7 +72,7 @@ pub struct ExampleOptions {
 }
 
 impl ExampleOptions {
-    pub fn to_proof_options(&self, q: usize, b: usize) -> (ProofOptions, HashFunction) {
+    pub fn to_proof_options(&self, q: u8, b: usize) -> (ProofOptions, HashFunction) {
         let num_queries = self.num_queries.unwrap_or(q);
         let blowup_factor = self.blowup_factor.unwrap_or(b);
         let field_extension = match self.field_extension {
@@ -90,15 +90,26 @@ impl ExampleOptions {
             val => panic!("'{val}' is not a valid hash function option"),
         };
 
+        let folding_factor = match self.folding_factor {
+            4 => FriFoldingFactor::First,
+            8 => FriFoldingFactor::Second,
+            16 => FriFoldingFactor::Third,
+            val => panic!("'{val}' is not a valid folding factor"),
+        };
+
+        let blowup_factor = BlowupFactor::try_from(blowup_factor)
+            .unwrap_or_else(|_| panic!("'{blowup_factor}' is not a valid blowup factor"));
+
         (
             ProofOptions::new(
                 num_queries,
                 blowup_factor,
                 self.grinding_factor,
                 field_extension,
-                self.folding_factor,
-                256,
-            ),
+                folding_factor,
+                FriMaximumRemainderSize::Fourth,
+            )
+            .expect("Proof options should be valid"),
             hash_fn,
         )
     }

--- a/examples/src/merkle/tests.rs
+++ b/examples/src/merkle/tests.rs
@@ -5,7 +5,9 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::Blake3_256;
-use winterfell::{FieldExtension, ProofOptions};
+use winterfell::{
+    BlowupFactor, FieldExtension, FriFoldingFactor, FriMaximumRemainderSize, ProofOptions,
+};
 
 #[test]
 fn merkle_test_basic_proof_verification() {
@@ -40,5 +42,13 @@ fn build_options(use_extension_field: bool) -> ProofOptions {
     } else {
         FieldExtension::None
     };
-    ProofOptions::new(28, 8, 0, extension, 4, 256)
+    ProofOptions::new(
+        28,
+        BlowupFactor::Third,
+        0,
+        extension,
+        FriFoldingFactor::First,
+        FriMaximumRemainderSize::Fourth,
+    )
+    .expect("Proof options should be valid")
 }

--- a/examples/src/rescue/rescue_128/tests.rs
+++ b/examples/src/rescue/rescue_128/tests.rs
@@ -5,7 +5,9 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::Blake3_256;
-use winterfell::{FieldExtension, ProofOptions};
+use winterfell::{
+    BlowupFactor, FieldExtension, FriFoldingFactor, FriMaximumRemainderSize, ProofOptions,
+};
 
 #[test]
 fn rescue_test_basic_proof_verification() {
@@ -40,5 +42,13 @@ fn build_options(use_extension_field: bool) -> ProofOptions {
     } else {
         FieldExtension::None
     };
-    ProofOptions::new(28, 8, 0, extension, 4, 256)
+    ProofOptions::new(
+        28,
+        BlowupFactor::Third,
+        0,
+        extension,
+        FriFoldingFactor::First,
+        FriMaximumRemainderSize::Fourth,
+    )
+    .expect("Proof options should be valid")
 }

--- a/examples/src/rescue_raps/tests.rs
+++ b/examples/src/rescue_raps/tests.rs
@@ -5,7 +5,9 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::Blake3_256;
-use winterfell::{FieldExtension, ProofOptions};
+use winterfell::{
+    BlowupFactor, FieldExtension, FriFoldingFactor, FriMaximumRemainderSize, ProofOptions,
+};
 
 #[test]
 fn rescue_test_basic_proof_verification() {
@@ -40,5 +42,13 @@ fn build_options(use_extension_field: bool) -> ProofOptions {
     } else {
         FieldExtension::None
     };
-    ProofOptions::new(28, 8, 0, extension, 4, 256)
+    ProofOptions::new(
+        28,
+        BlowupFactor::Third,
+        0,
+        extension,
+        FriFoldingFactor::First,
+        FriMaximumRemainderSize::Fourth,
+    )
+    .expect("Proof options should be valid")
 }

--- a/examples/src/vdf/exempt/tests.rs
+++ b/examples/src/vdf/exempt/tests.rs
@@ -5,7 +5,9 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::Blake3_256;
-use winterfell::{FieldExtension, ProofOptions};
+use winterfell::{
+    BlowupFactor, FieldExtension, FriFoldingFactor, FriMaximumRemainderSize, ProofOptions,
+};
 
 #[test]
 fn vdf_test_basic_proof_verification() {
@@ -40,5 +42,13 @@ fn build_options(use_extension_field: bool) -> ProofOptions {
     } else {
         FieldExtension::None
     };
-    ProofOptions::new(85, 2, 0, extension, 4, 256)
+    ProofOptions::new(
+        85,
+        BlowupFactor::First,
+        0,
+        extension,
+        FriFoldingFactor::First,
+        FriMaximumRemainderSize::Fourth,
+    )
+    .expect("Proof options should be valid")
 }

--- a/examples/src/vdf/regular/tests.rs
+++ b/examples/src/vdf/regular/tests.rs
@@ -5,7 +5,9 @@
 // LICENSE file in the root directory of this source tree.
 
 use super::Blake3_256;
-use winterfell::{FieldExtension, ProofOptions};
+use winterfell::{
+    BlowupFactor, FieldExtension, FriFoldingFactor, FriMaximumRemainderSize, ProofOptions,
+};
 
 #[test]
 fn vdf_test_basic_proof_verification() {
@@ -40,5 +42,13 @@ fn build_options(use_extension_field: bool) -> ProofOptions {
     } else {
         FieldExtension::None
     };
-    ProofOptions::new(85, 2, 0, extension, 4, 256)
+    ProofOptions::new(
+        85,
+        BlowupFactor::First,
+        0,
+        extension,
+        FriFoldingFactor::First,
+        FriMaximumRemainderSize::Fourth,
+    )
+    .expect("Proof options should be valid")
 }

--- a/math/src/curve/cheetah/mod.rs
+++ b/math/src/curve/cheetah/mod.rs
@@ -741,10 +741,10 @@ mod tests {
 
     #[test]
     fn test_is_on_curve() {
-        assert!(bool::from(AffinePoint::identity().is_on_curve()));
-        assert!(bool::from(AffinePoint::generator().is_on_curve()));
-        assert!(bool::from(ProjectivePoint::identity().is_on_curve()));
-        assert!(bool::from(ProjectivePoint::generator().is_on_curve()));
+        assert!(AffinePoint::identity().is_on_curve());
+        assert!(AffinePoint::generator().is_on_curve());
+        assert!(ProjectivePoint::identity().is_on_curve());
+        assert!(ProjectivePoint::generator().is_on_curve());
 
         let z = Fp6::from_raw_unchecked([
             0x29eedd8f12973c87,
@@ -760,14 +760,13 @@ mod tests {
         coordinates[0..6].copy_from_slice(&(gen.0.get_x() * z).output_internal());
         coordinates[6..12].copy_from_slice(&(gen.0.get_y() * z).output_internal());
         coordinates[12..18].copy_from_slice(&z.output_internal());
-        let mut test =
-            ProjectivePoint::from_raw_coordinates(coordinates.map(|e| BaseElement::new(e)));
+        let mut test = ProjectivePoint::from_raw_coordinates(coordinates.map(BaseElement::new));
 
-        assert!(bool::from(test.is_on_curve()));
+        assert!(test.is_on_curve());
 
         coordinates[0..6].copy_from_slice(&z.output_internal());
-        test = ProjectivePoint::from_raw_coordinates(coordinates.map(|e| BaseElement::new(e)));
-        assert!(!bool::from(test.is_on_curve()));
+        test = ProjectivePoint::from_raw_coordinates(coordinates.map(BaseElement::new));
+        assert!(!test.is_on_curve());
     }
 
     #[test]
@@ -783,8 +782,8 @@ mod tests {
         assert!(a != b);
         assert!(b != a);
 
-        assert!(bool::from(b.is_identity()));
-        assert!(!bool::from(a.eq(&b)));
+        assert!(b.is_identity());
+        assert!(!a.eq(&b));
     }
 
     #[test]
@@ -800,8 +799,8 @@ mod tests {
         assert!(a != b);
         assert!(b != a);
 
-        assert!(bool::from(b.is_identity()));
-        assert!(!bool::from(a.eq(&b)));
+        assert!(b.is_identity());
+        assert!(!a.eq(&b));
 
         let z = Fp6::from_raw_unchecked([
             0x29eedd8f12973c87,
@@ -816,8 +815,8 @@ mod tests {
         coordinates[0..6].copy_from_slice(&(a.0.get_x() * z).output_internal());
         coordinates[6..12].copy_from_slice(&(a.0.get_y() * z).output_internal());
         coordinates[12..18].copy_from_slice(&z.output_internal());
-        let mut c = ProjectivePoint::from_raw_coordinates(coordinates.map(|e| BaseElement::new(e)));
-        assert!(bool::from(c.is_on_curve()));
+        let mut c = ProjectivePoint::from_raw_coordinates(coordinates.map(BaseElement::new));
+        assert!(c.is_on_curve());
 
         assert!(a == c);
         assert!(b != c);
@@ -825,8 +824,8 @@ mod tests {
         assert!(c != b);
 
         coordinates[6..12].copy_from_slice(&(-a.0.get_y() * z).output_internal());
-        c = ProjectivePoint::from_raw_coordinates(coordinates.map(|e| BaseElement::new(e)));
-        assert!(bool::from(c.is_on_curve()));
+        c = ProjectivePoint::from_raw_coordinates(coordinates.map(BaseElement::new));
+        assert!(c.is_on_curve());
 
         assert!(a != c);
         assert!(b != c);
@@ -835,8 +834,8 @@ mod tests {
 
         coordinates[0..6].copy_from_slice(&z.output_internal());
         coordinates[6..12].copy_from_slice(&(a.0.get_y() * z).output_internal());
-        c = ProjectivePoint::from_raw_coordinates(coordinates.map(|e| BaseElement::new(e)));
-        assert!(!bool::from(c.is_on_curve()));
+        c = ProjectivePoint::from_raw_coordinates(coordinates.map(BaseElement::new));
+        assert!(!c.is_on_curve());
         assert!(a != b);
         assert!(a != c);
         assert!(b != c);
@@ -847,10 +846,10 @@ mod tests {
         let a = ProjectivePoint::generator();
         let b = ProjectivePoint::identity();
 
-        assert!(bool::from(AffinePoint::from(a).is_on_curve()));
-        assert!(!bool::from(AffinePoint::from(a).is_identity()));
-        assert!(bool::from(AffinePoint::from(b).is_on_curve()));
-        assert!(bool::from(AffinePoint::from(b).is_identity()));
+        assert!(AffinePoint::from(a).is_on_curve());
+        assert!(!AffinePoint::from(a).is_identity());
+        assert!(AffinePoint::from(b).is_on_curve());
+        assert!(AffinePoint::from(b).is_identity());
 
         let z = Fp6::from_raw_unchecked([
             0x29eedd8f12973c87,
@@ -865,7 +864,7 @@ mod tests {
         coordinates[0..6].copy_from_slice(&(a.0.get_x() * z).output_internal());
         coordinates[6..12].copy_from_slice(&(a.0.get_y() * z).output_internal());
         coordinates[12..18].copy_from_slice(&z.output_internal());
-        let c = ProjectivePoint::from_raw_coordinates(coordinates.map(|e| BaseElement::new(e)));
+        let c = ProjectivePoint::from_raw_coordinates(coordinates.map(BaseElement::new));
 
         assert_eq!(AffinePoint::from(c), AffinePoint::generator());
     }
@@ -875,23 +874,23 @@ mod tests {
         let a = AffinePoint::generator();
         let b = AffinePoint::identity();
 
-        assert!(bool::from(ProjectivePoint::from(a).is_on_curve()));
-        assert!(!bool::from(ProjectivePoint::from(a).is_identity()));
-        assert!(bool::from(ProjectivePoint::from(b).is_on_curve()));
-        assert!(bool::from(ProjectivePoint::from(b).is_identity()));
+        assert!(ProjectivePoint::from(a).is_on_curve());
+        assert!(!ProjectivePoint::from(a).is_identity());
+        assert!(ProjectivePoint::from(b).is_on_curve());
+        assert!(ProjectivePoint::from(b).is_identity());
     }
 
     #[test]
     fn test_doubling() {
         {
             let tmp = ProjectivePoint::identity().double();
-            assert!(bool::from(tmp.is_identity()));
-            assert!(bool::from(tmp.is_on_curve()));
+            assert!(tmp.is_identity());
+            assert!(tmp.is_on_curve());
         }
         {
             let tmp = ProjectivePoint::generator().double();
-            assert!(!bool::from(tmp.is_identity()));
-            assert!(bool::from(tmp.is_on_curve()));
+            assert!(!tmp.is_identity());
+            assert!(tmp.is_on_curve());
 
             assert_eq!(
                 AffinePoint::from(tmp),
@@ -919,8 +918,8 @@ mod tests {
             let a = ProjectivePoint::identity();
             let b = ProjectivePoint::identity();
             let c = a + b;
-            assert!(bool::from(c.is_identity()));
-            assert!(bool::from(c.is_on_curve()));
+            assert!(c.is_identity());
+            assert!(c.is_on_curve());
         }
         {
             let a = ProjectivePoint::identity();
@@ -939,11 +938,11 @@ mod tests {
                 coordinates[0..6].copy_from_slice(&(b.0.get_x() * z).output_internal());
                 coordinates[6..12].copy_from_slice(&(b.0.get_y() * z).output_internal());
                 coordinates[12..18].copy_from_slice(&z.output_internal());
-                b = ProjectivePoint::from_raw_coordinates(coordinates.map(|e| BaseElement::new(e)));
+                b = ProjectivePoint::from_raw_coordinates(coordinates.map(BaseElement::new));
             }
             let c = a + b;
-            assert!(!bool::from(c.is_identity()));
-            assert!(bool::from(c.is_on_curve()));
+            assert!(!c.is_identity());
+            assert!(c.is_on_curve());
             assert!(c == ProjectivePoint::generator());
         }
         {
@@ -955,10 +954,10 @@ mod tests {
             for _ in 0..5 {
                 d += ProjectivePoint::generator();
             }
-            assert!(!bool::from(c.is_identity()));
-            assert!(bool::from(c.is_on_curve()));
-            assert!(!bool::from(d.is_identity()));
-            assert!(bool::from(d.is_on_curve()));
+            assert!(!c.is_identity());
+            assert!(c.is_on_curve());
+            assert!(!d.is_identity());
+            assert!(d.is_on_curve());
             assert_eq!(c, d);
         }
     }
@@ -969,8 +968,8 @@ mod tests {
             let a = AffinePoint::identity();
             let b = ProjectivePoint::identity();
             let c = a + b;
-            assert!(bool::from(c.is_identity()));
-            assert!(bool::from(c.is_on_curve()));
+            assert!(c.is_identity());
+            assert!(c.is_on_curve());
         }
         {
             let a = AffinePoint::identity();
@@ -989,11 +988,11 @@ mod tests {
                 coordinates[0..6].copy_from_slice(&(b.0.get_x() * z).output_internal());
                 coordinates[6..12].copy_from_slice(&(b.0.get_y() * z).output_internal());
                 coordinates[12..18].copy_from_slice(&z.output_internal());
-                b = ProjectivePoint::from_raw_coordinates(coordinates.map(|e| BaseElement::new(e)));
+                b = ProjectivePoint::from_raw_coordinates(coordinates.map(BaseElement::new));
             }
             let c = a + b;
-            assert!(!bool::from(c.is_identity()));
-            assert!(bool::from(c.is_on_curve()));
+            assert!(!c.is_identity());
+            assert!(c.is_on_curve());
             assert!(c == ProjectivePoint::generator());
         }
         {
@@ -1005,10 +1004,10 @@ mod tests {
             for _ in 0..5 {
                 d += AffinePoint::generator();
             }
-            assert!(!bool::from(c.is_identity()));
-            assert!(bool::from(c.is_on_curve()));
-            assert!(!bool::from(d.is_identity()));
-            assert!(bool::from(d.is_on_curve()));
+            assert!(!c.is_identity());
+            assert!(c.is_on_curve());
+            assert!(!d.is_identity());
+            assert!(d.is_on_curve());
             assert_eq!(c, d);
         }
     }
@@ -1076,7 +1075,7 @@ mod tests {
         ]);
         let c = a * b;
 
-        assert_eq!(AffinePoint::from(g * a) * b, g * c);
+        assert_eq!((g * a) * b, g * c);
 
         for _ in 0..100 {
             let a: Scalar = rand_value();
@@ -1091,9 +1090,9 @@ mod tests {
     fn test_clear_cofactor() {
         // the generator (and the identity) are always on the curve
         let generator = ProjectivePoint::generator();
-        assert!(bool::from(generator.clear_cofactor().is_on_curve()));
+        assert!(generator.clear_cofactor().is_on_curve());
         let id = ProjectivePoint::identity();
-        assert!(bool::from(id.clear_cofactor().is_on_curve()));
+        assert!(id.clear_cofactor().is_on_curve());
 
         let point = ProjectivePoint::from(&AffinePoint::from_raw_coordinates([
             BaseElement::new(0x9bfcd3244afcb637),
@@ -1113,7 +1112,7 @@ mod tests {
         assert!(point.is_on_curve());
         assert!(!AffinePoint::from(point).is_torsion_free());
         let cleared_point = point.clear_cofactor();
-        assert!(bool::from(cleared_point.is_on_curve()));
+        assert!(cleared_point.is_on_curve());
         assert!(AffinePoint::from(cleared_point).is_torsion_free());
     }
 
@@ -1134,10 +1133,10 @@ mod tests {
             BaseElement::new(0x5b8157814141a7a7),
         ]);
 
-        assert!(bool::from(a.is_on_curve()));
-        assert!(!bool::from(a.is_torsion_free()));
-        assert!(bool::from(AffinePoint::identity().is_torsion_free()));
-        assert!(bool::from(AffinePoint::generator().is_torsion_free()));
+        assert!(a.is_on_curve());
+        assert!(!a.is_torsion_free());
+        assert!(AffinePoint::identity().is_torsion_free());
+        assert!(AffinePoint::generator().is_torsion_free());
     }
 
     #[test]

--- a/math/src/curve/cheetah/scalar.rs
+++ b/math/src/curve/cheetah/scalar.rs
@@ -460,7 +460,7 @@ mod tests {
         assert_eq!(Scalar::one(), Scalar::one());
 
         assert!(bool::from(Scalar::default().is_zero()));
-        assert!(!bool::from(Scalar::zero().eq(&Scalar::one())));
+        assert!(Scalar::zero().eq(&Scalar::one()));
 
         assert!(Scalar::zero() != Scalar::one());
     }
@@ -679,29 +679,23 @@ mod tests {
         );
 
         // M is invalid
-        assert!(bool::from(
-            Scalar::from_bytes(&[
-                207, 172, 212, 174, 62, 98, 67, 212, 34, 119, 21, 48, 35, 167, 122, 50, 181, 55,
-                10, 153, 15, 191, 63, 86, 208, 34, 63, 59, 155, 89, 242, 122
-            ])
-            .is_none()
-        ));
+        assert!(Scalar::from_bytes(&[
+            207, 172, 212, 174, 62, 98, 67, 212, 34, 119, 21, 48, 35, 167, 122, 50, 181, 55, 10,
+            153, 15, 191, 63, 86, 208, 34, 63, 59, 155, 89, 242, 122
+        ])
+        .is_none());
 
         // Anything larger than M is invalid
-        assert!(bool::from(
-            Scalar::from_bytes(&[
-                206, 173, 212, 174, 62, 98, 67, 212, 34, 119, 21, 48, 35, 167, 122, 50, 181, 55,
-                10, 153, 15, 191, 63, 86, 208, 34, 63, 59, 155, 89, 242, 122
-            ])
-            .is_none()
-        ));
-        assert!(bool::from(
-            Scalar::from_bytes(&[
-                0, 0, 0, 174, 62, 98, 67, 212, 34, 119, 21, 48, 35, 167, 122, 50, 181, 55, 10, 153,
-                15, 191, 63, 86, 208, 34, 63, 59, 155, 89, 242, 255
-            ])
-            .is_none()
-        ));
+        assert!(Scalar::from_bytes(&[
+            206, 173, 212, 174, 62, 98, 67, 212, 34, 119, 21, 48, 35, 167, 122, 50, 181, 55, 10,
+            153, 15, 191, 63, 86, 208, 34, 63, 59, 155, 89, 242, 122
+        ])
+        .is_none());
+        assert!(Scalar::from_bytes(&[
+            0, 0, 0, 174, 62, 98, 67, 212, 34, 119, 21, 48, 35, 167, 122, 50, 181, 55, 10, 153, 15,
+            191, 63, 86, 208, 34, 63, 59, 155, 89, 242, 255
+        ])
+        .is_none());
     }
 
     #[test]
@@ -743,8 +737,8 @@ mod tests {
         ]);
 
         assert_eq!(a.square(), b.square());
-        assert!(!bool::from(a.lexicographically_largest()));
-        assert!(bool::from(b.lexicographically_largest()));
+        assert!(!a.lexicographically_largest());
+        assert!(b.lexicographically_largest());
     }
 
     // INITIALIZATION

--- a/math/src/curve/cheetah/scalar.rs
+++ b/math/src/curve/cheetah/scalar.rs
@@ -460,7 +460,7 @@ mod tests {
         assert_eq!(Scalar::one(), Scalar::one());
 
         assert!(bool::from(Scalar::default().is_zero()));
-        assert!(Scalar::zero().eq(&Scalar::one()));
+        assert!(!Scalar::zero().eq(&Scalar::one()));
 
         assert!(Scalar::zero() != Scalar::one());
     }

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -45,10 +45,11 @@
 extern crate alloc;
 
 pub use air::{
-    proof::StarkProof, Air, AirContext, Assertion, AuxTraceRandElements, BoundaryConstraint,
-    BoundaryConstraintGroup, ConstraintCompositionCoefficients, ConstraintDivisor,
-    DeepCompositionCoefficients, EvaluationFrame, FieldExtension, ProofOptions, TraceInfo,
-    TraceLayout, TransitionConstraintDegree, TransitionConstraintGroup,
+    proof::StarkProof, Air, AirContext, Assertion, AuxTraceRandElements, BlowupFactor,
+    BoundaryConstraint, BoundaryConstraintGroup, ConstraintCompositionCoefficients,
+    ConstraintDivisor, DeepCompositionCoefficients, EvaluationFrame, FieldExtension,
+    FriFoldingFactor, FriMaximumRemainderSize, ProofOptions, TraceInfo, TraceLayout,
+    TransitionConstraintDegree, TransitionConstraintGroup,
 };
 pub use utils::{
     iterators, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,

--- a/prover/src/tests/mod.rs
+++ b/prover/src/tests/mod.rs
@@ -6,8 +6,8 @@
 
 use crate::TraceTable;
 use air::{
-    Air, AirContext, Assertion, EvaluationFrame, FieldExtension, ProofOptions, TraceInfo,
-    TransitionConstraintDegree,
+    Air, AirContext, Assertion, BlowupFactor, EvaluationFrame, FieldExtension, FriFoldingFactor,
+    FriMaximumRemainderSize, ProofOptions, TraceInfo, TransitionConstraintDegree,
 };
 use math::{fields::f128::BaseElement, FieldElement, StarkField};
 use utils::collections::Vec;
@@ -43,7 +43,15 @@ impl MockAir {
         Self::new(
             TraceInfo::new(4, trace_length),
             (),
-            ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 256),
+            ProofOptions::new(
+                32,
+                BlowupFactor::Third,
+                0,
+                FieldExtension::None,
+                FriFoldingFactor::First,
+                FriMaximumRemainderSize::Fourth,
+            )
+            .expect("Proof options should be valid"),
         )
     }
 
@@ -54,7 +62,15 @@ impl MockAir {
         let mut result = Self::new(
             TraceInfo::new(4, trace_length),
             (),
-            ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 256),
+            ProofOptions::new(
+                32,
+                BlowupFactor::Third,
+                0,
+                FieldExtension::None,
+                FriFoldingFactor::First,
+                FriMaximumRemainderSize::Fourth,
+            )
+            .expect("Proof options should be valid"),
         );
         result.periodic_columns = column_values;
         result
@@ -64,7 +80,15 @@ impl MockAir {
         let mut result = Self::new(
             TraceInfo::new(4, trace_length),
             (),
-            ProofOptions::new(32, 8, 0, FieldExtension::None, 4, 256),
+            ProofOptions::new(
+                32,
+                BlowupFactor::Third,
+                0,
+                FieldExtension::None,
+                FriFoldingFactor::First,
+                FriMaximumRemainderSize::Fourth,
+            )
+            .expect("Proof options should be valid"),
         );
         result.assertions = assertions;
         result
@@ -76,7 +100,7 @@ impl Air for MockAir {
     type PublicInputs = ();
 
     fn new(trace_info: TraceInfo, _pub_inputs: (), _options: ProofOptions) -> Self {
-        let context = build_context(trace_info, 8, 1);
+        let context = build_context(trace_info, BlowupFactor::Third, 1);
         MockAir {
             context,
             assertions: Vec::new(),
@@ -110,10 +134,18 @@ impl Air for MockAir {
 
 fn build_context<B: StarkField>(
     trace_info: TraceInfo,
-    blowup_factor: usize,
+    blowup_factor: BlowupFactor,
     num_assertions: usize,
 ) -> AirContext<B> {
-    let options = ProofOptions::new(32, blowup_factor, 0, FieldExtension::None, 4, 256);
+    let options = ProofOptions::new(
+        32,
+        blowup_factor,
+        0,
+        FieldExtension::None,
+        FriFoldingFactor::First,
+        FriMaximumRemainderSize::Fourth,
+    )
+    .expect("Proof options should be valid");
     let t_degrees = vec![TransitionConstraintDegree::new(2)];
     AirContext::new(trace_info, t_degrees, num_assertions, options)
 }

--- a/utils/core/src/errors.rs
+++ b/utils/core/src/errors.rs
@@ -15,6 +15,8 @@ use core::fmt;
 pub enum DeserializationError {
     /// Bytes in the input do not represent a valid value.
     InvalidValue(String),
+    /// An invalid proof option was chosen
+    ProofOption(ProofOptionError),
     /// An end of input was reached before a valid value could be deserialized.
     UnexpectedEOF,
     /// Deserialization has finished but not all bytes have been consumed.
@@ -30,6 +32,7 @@ impl fmt::Display for DeserializationError {
             Self::InvalidValue(err_msg) => {
                 write!(f, "{err_msg}")
             }
+            Self::ProofOption(error) => error.fmt(f),
             Self::UnexpectedEOF => {
                 write!(f, "unexpected EOF")
             }
@@ -40,5 +43,34 @@ impl fmt::Display for DeserializationError {
                 write!(f, "unknown error: {err_msg}")
             }
         }
+    }
+}
+
+impl From<ProofOptionError> for DeserializationError {
+    fn from(error: ProofOptionError) -> Self {
+        Self::ProofOption(error)
+    }
+}
+
+// PROOF OPTION ERROR
+// ================================================================================================
+
+// Surfaces errors with particular ProofOption values that are requested
+#[derive(Debug, Eq, PartialEq)]
+pub enum ProofOptionError {
+    NumberOfQueries,
+    GrindingFactor,
+}
+
+impl fmt::Display for ProofOptionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::NumberOfQueries => "number of queries cannot be greater than 128",
+                Self::GrindingFactor => "grinding factor cannot be greater than 32",
+            }
+        )
     }
 }

--- a/utils/core/src/lib.rs
+++ b/utils/core/src/lib.rs
@@ -24,7 +24,7 @@ use string::ToString;
 pub mod iterators;
 
 mod errors;
-pub use errors::DeserializationError;
+pub use errors::{DeserializationError, ProofOptionError};
 
 #[cfg(test)]
 mod tests;

--- a/winterfell/src/lib.rs
+++ b/winterfell/src/lib.rs
@@ -485,11 +485,11 @@
 //! // Define proof options; these will be enough for ~96-bit security level.
 //! let options = ProofOptions::new(
 //!     32, // number of queries
-//!     8,  // blowup factor
+//!     BlowupFactor::Third,  // blowup factor
 //!     0,  // grinding factor
 //!     FieldExtension::None,
-//!     8,   // FRI folding factor
-//!     128, // FRI max remainder length
+//!     FriFoldingFactor::Third,   // FRI folding factor
+//!     FriMaximumRemainderSize::Fourth, // FRI max remainder length
 //! );
 //!
 //! // Instantiate the prover and generate the proof.
@@ -528,11 +528,12 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use prover::{
-    crypto, iterators, math, Air, AirContext, Assertion, AuxTraceRandElements, BoundaryConstraint,
-    BoundaryConstraintGroup, ByteReader, ByteWriter, ConstraintCompositionCoefficients,
-    ConstraintDivisor, DeepCompositionCoefficients, Deserializable, DeserializationError,
-    EvaluationFrame, FieldExtension, Matrix, ProofOptions, Prover, ProverError, Serializable,
-    SliceReader, StarkProof, Trace, TraceInfo, TraceLayout, TraceTable, TraceTableFragment,
+    crypto, iterators, math, Air, AirContext, Assertion, AuxTraceRandElements, BlowupFactor,
+    BoundaryConstraint, BoundaryConstraintGroup, ByteReader, ByteWriter,
+    ConstraintCompositionCoefficients, ConstraintDivisor, DeepCompositionCoefficients,
+    Deserializable, DeserializationError, EvaluationFrame, FieldExtension, FriFoldingFactor,
+    FriMaximumRemainderSize, Matrix, ProofOptions, Prover, ProverError, Serializable, SliceReader,
+    StarkProof, Trace, TraceInfo, TraceLayout, TraceTable, TraceTableFragment,
     TransitionConstraintDegree, TransitionConstraintGroup,
 };
 pub use verifier::{verify, VerifierError};

--- a/winterfell/src/lib.rs
+++ b/winterfell/src/lib.rs
@@ -368,7 +368,7 @@
 //! ```
 //! # use winterfell::{
 //! #    math::{fields::f128::BaseElement, FieldElement},
-//! #    Air, AirContext, Assertion, ByteWriter, EvaluationFrame, Serializable,
+//! #    Air, AirContext, Assertion, BlowupFactor, ByteWriter, EvaluationFrame, FriFoldingFactor, FriMaximumRemainderSize, Serializable,
 //! #    TraceInfo, TransitionConstraintDegree, TraceTable, FieldExtension,
 //! #    Prover, ProofOptions, StarkProof, Trace, crypto::hashers::Blake3_256,
 //! # };
@@ -490,7 +490,7 @@
 //!     FieldExtension::None,
 //!     FriFoldingFactor::Third,   // FRI folding factor
 //!     FriMaximumRemainderSize::Fourth, // FRI max remainder length
-//! );
+//! ).unwrap();
 //!
 //! // Instantiate the prover and generate the proof.
 //! let prover = WorkProver::new(options);


### PR DESCRIPTION
`ProofOptions` is made pure (returns errors instead of panicking), and is refactored to make it much harder to initialize with invalid options.